### PR TITLE
WIP: Story/TP-48573 Update PHP to use the official container from dockerhub

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN set -eux; \
 
 RUN apt-get update && apt-get install -y --force-yes \
     # Apache\PHP
-    libphp-predis \
+    php7.2-dev php7.2-gd libhiredis-dev libhiredis0.13  libphp-predis \
     # Build Deps
     build-essential curl make \
     # Other Deps

--- a/Dockerfile
+++ b/Dockerfile
@@ -81,6 +81,5 @@ COPY php/conf.d/* /usr/local/etc/php/7.2/cli/conf.d/
 COPY apache2-foreground /usr/local/bin/
 
 # PHP Config
-RUN mv "$PHP_INI_DIR/php.ini-production" "/usr/local/etc/php/php.ini"
 
 CMD ["apache2-foreground"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,6 @@ RUN pecl config-set php_ini "$PHP_INI_DIR" \
     && pecl install apcu-5.1.12 \
     && pecl install redis-5.0.1 \
     && docker-php-ext-enable redis \
-    && docker-php-ext-install mysqli
     && docker-php-ext-install mysqli \
     && docker-php-ext-enable redis xdebug
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,9 @@ RUN pecl config-set php_ini "$PHP_INI_DIR" \
     && pecl install apcu-5.1.12 \
     && pecl install redis-5.0.1 \
     && docker-php-ext-install mysqli \
-    && docker-php-ext-enable redis xdebug mysqli
+    && docker-php-ext-enable redis \
+    && docker-php-ext-enable xdebug \
+    && docker-php-ext-enable mysqli
 
 RUN a2enmod ssl \
     && a2enmod rewrite \

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,7 @@ RUN pecl config-set php_ini "$PHP_INI_DIR" \
     && pear install PHP_CodeSniffer \
     && pecl install xdebug-2.6.1 \
     && pecl install apcu-5.1.12 \
+    && docker-php-ext-enable apcu \
     && pecl install redis-5.0.1 \
     && docker-php-ext-enable redis \
     && docker-php-ext-install mysqli \

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,16 @@ RUN apt-get update && apt-get install -y --force-yes \
     pdftk zip git libpng-dev libjpeg-dev libfreetype6-dev
 
 
-RUN pecl config-set php_ini "$PHP_INI_DIR" \
+RUN docker-php-ext-configure gd \
+    --with-gd \
+    --with-webp-dir \
+    --with-jpeg-dir \
+    --with-png-dir \
+    --with-zlib-dir \
+    --with-xpm-dir \
+    --with-freetype-dir \
+    --enable-gd-native-ttf \
+    && pecl config-set php_ini "$PHP_INI_DIR" \
     && pear install PHP_CodeSniffer \
     && pecl install apcu-5.1.12 \
     && pecl install redis-5.0.1 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,9 +27,7 @@ RUN apt-get update && apt-get install -y --force-yes \
     # Other Deps
     pdftk zip git libpng-dev libjpeg-dev \
     && apt-get clean \
-    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
-    && docker-php-ext-install mysqli \
-    && docker-php-ext-install gd
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 
 RUN curl -s -o phpunit-7.3.2.phar https://phar.phpunit.de/phpunit-7.3.2.phar \
@@ -39,7 +37,9 @@ RUN curl -s -o phpunit-7.3.2.phar https://phar.phpunit.de/phpunit-7.3.2.phar \
 RUN pecl config-set php_ini "$PHP_INI_DIR" \
     && pear install PHP_CodeSniffer \
     && pecl install apcu-5.1.12 \
-    && pecl install redis-5.0.1
+    && pecl install redis-5.0.1 \
+    && docker-php-ext-install mysqli \
+    && docker-php-ext-install gd
 
 RUN a2enmod ssl \
     && a2enmod rewrite \

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,11 +5,12 @@ ENV DEBIAN_FRONTEND noninteractive
 
 RUN mkdir -p /var/run/apache2 /var/lock/apache2
 
-
-RUN apt-get update && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
-
-RUN apt-get update && apt-get install -y --force-yes\
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install apt-utils apt-transport-https software-properties-common
+
+RUN apt-get update && LC_ALL=C.UTF-8 add-apt-repository 'deb https://packages.sury.org/php/ stretch main' \
+    && apt-key adv --fetch-keys https://packages.sury.org/php/apt.gpg
+
+RUN apt-get update && apt-get install -y --force-yes \
     # Apache\PHP
     apache2 libapache2-mod-gnutls libapache2-mod-php7.2 php7.2 php7.2-curl php7.2-common php7.2-dev php7.2-mbstring php7.2-curl php7.2-cli php7.2-mysql php7.2-gd php7.2-intl php7.2-xsl php7.2-zip php-xcache php-pear php7.2-gd php-xml-parser php-memcached libhiredis-dev libhiredis0.13 libphp-predis \
     # Mogile

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,12 @@ RUN apt-get update && LC_ALL=C.UTF-8 add-apt-repository 'deb https://packages.su
 
 # Use the default production configuration
 # except Prioritize Sury php-gd package
+RUN set -eux; \
+	{ \
+		echo 'Package: php*-gd'; \
+		echo 'Pin: release *'; \
+		echo 'Pin-Priority: 1'; \
+	} >> /etc/apt/preferences.d/no-debian-php
 
 RUN apt-get update && apt-get install -y --force-yes \
     # Apache\PHP

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ RUN pecl config-set php_ini "$PHP_INI_DIR" \
     && pecl install redis-5.0.1 \
     && docker-php-ext-enable redis \
     && docker-php-ext-install mysqli \
-    && docker-php-ext-enable redis xdebug
+    && docker-php-ext-enable redis xdebug mysqli
 
 RUN a2enmod ssl \
     && a2enmod rewrite \

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,9 +17,11 @@ RUN set -eux; \
 		echo 'Package: php*-gd'; \
 		echo 'Pin: release *'; \
 		echo 'Pin-Priority: 1'; \
+	} >> /etc/apt/preferences.d/no-debian-php \
     && mkdir -p /etc/php/7.2/apache2 && mkdir -p /etc/php/7.2/cli \
-    && cp "$PHP_INI_DIR/php.ini-development" "/etc/php/7.2/apache2/php.ini"
-	} >> /etc/apt/preferences.d/no-debian-php
+    && cp "$PHP_INI_DIR/php.ini-production" "/etc/php/7.2/apache2/php.ini" \
+    && mv "$PHP_INI_DIR/php.ini-production" "/etc/php/7.2/cli/php.ini"
+
 RUN apt-get update && apt-get install -y --force-yes \
     # Apache\PHP
     apache2 libapache2-mod-gnutls libapache2-mod-php7.2 php7.2 php7.2-curl php7.2-common php7.2-dev php7.2-mbstring php7.2-curl php7.2-cli php7.2-mysql php7.2-gd php7.2-intl php7.2-xsl php7.2-zip php-xcache php-pear php7.2-gd php-xml-parser php-memcached libhiredis-dev libhiredis0.13 libphp-predis \

--- a/Dockerfile
+++ b/Dockerfile
@@ -64,8 +64,8 @@ ENV APACHE_RUN_DIR /var/run/apache2
 ENV APPLICATION_ENV local
 
 COPY apache2/apache2.conf /etc/apache2/
-COPY php/conf.d/ /etc/php/7.2/apache2/conf.d/
-COPY php/conf.d/ /etc/php/7.2/cli/conf.d/
+COPY php/conf.d/* /usr/local/etc/php/7.2/apache2/conf.d/
+COPY php/conf.d/* /usr/local/etc/php/7.2/cli/conf.d/
 
 COPY apache2-foreground /usr/local/bin/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN set -eux; \
 
 RUN apt-get update && apt-get install -y --force-yes \
     # Apache\PHP
-    php-gd libhiredis-dev libhiredis0.13 libphp-predis \
+    php7.2-mysql php-gd libhiredis-dev libhiredis0.13 libphp-predis \
     # Build Deps
     build-essential curl make \
     # Other Deps

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,9 @@ RUN apt-get update && LC_ALL=C.UTF-8 add-apt-repository 'deb https://packages.su
 # except Prioritize Sury php-gd package
 RUN set -eux; \
 	{ \
+		echo 'Package: php*-redis'; \
+		echo 'Pin: release *'; \
+		echo 'Pin-Priority: 1'; \
 		echo 'Package: php*-gd'; \
 		echo 'Pin: release *'; \
 		echo 'Pin-Priority: 1'; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN apt-get update && LC_ALL=C.UTF-8 add-apt-repository 'deb https://packages.su
 
 RUN apt-get update && apt-get install -y --force-yes \
     # Apache\PHP
-    php7.2-mysql php7.2-dev php7.2-gd libhiredis-dev libhiredis0.13  libphp-predis \
+    libhiredis-dev libhiredis0.13  libphp-predis \
     # Build Deps
     build-essential curl make \
     # Other Deps

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,7 @@ RUN pecl config-set php_ini "$PHP_INI_DIR" \
     && pear install PHP_CodeSniffer \
     && pecl install apcu-5.1.12 \
     && pecl install redis-5.0.1 \
+    && docker-php-ext-install mysqli \
     && docker-php-ext-enable redis xdebug mysqli
 
 RUN a2enmod ssl \

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,11 +31,11 @@ RUN set -eux; \
 
 RUN apt-get update && apt-get install -y --force-yes \
     # Apache\PHP
-    php*-mysql php*-dev php-gd php-redis libhiredis-dev libhiredis0.13 libphp-predis \
+    php*-mysql php*-dev php*-gd php-redis libhiredis-dev libhiredis0.13 libphp-predis \
     # Build Deps
     build-essential curl make \
     # Other Deps
-    pdftk zip git libpng-dev libjpeg-dev
+    pdftk zip git libpng-dev libjpeg-dev libfreetype6-dev
 
 
 RUN pecl config-set php_ini "$PHP_INI_DIR" \
@@ -45,8 +45,6 @@ RUN pecl config-set php_ini "$PHP_INI_DIR" \
     && docker-php-ext-enable redis \
     && docker-php-ext-install mysqli \
     && docker-php-ext-install gd
-
-RUN php -m && ls -altr /usr/local/etc/php/conf.d
 
 RUN curl -s -o phpunit-7.3.2.phar https://phar.phpunit.de/phpunit-7.3.2.phar \
     && chmod 777 phpunit-7.3.2.phar \
@@ -82,6 +80,5 @@ COPY php/conf.d/* /usr/local/etc/php/7.2/cli/conf.d/
 
 COPY apache2-foreground /usr/local/bin/
 
-RUN php -m && ls -altr /usr/local/etc/php/conf.d
 
 CMD ["apache2-foreground"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ RUN apt-get update && apt-get install -y --force-yes \
     # Build Deps
     build-essential curl make \
     # Other Deps
-    pdftk zip git libpng-dev libjpeg-dev libfreetype6-dev libwebp-dev
+    pdftk zip git libpng-dev libjpeg-dev libfreetype6-dev libwebp-dev libxpm-dev
 
 
 RUN docker-php-ext-configure gd \

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,7 @@ RUN pecl config-set php_ini "$PHP_INI_DIR" \
     && pecl install redis-5.0.1 \
     && docker-php-ext-enable redis \
     && docker-php-ext-install mysqli \
+    && docker-php-ext-install zip \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
     && docker-php-ext-install -j$(nproc) gd
 
@@ -80,7 +81,5 @@ COPY php/conf.d/* /usr/local/etc/php/7.2/apache2/conf.d/
 COPY php/conf.d/* /usr/local/etc/php/7.2/cli/conf.d/
 
 COPY apache2-foreground /usr/local/bin/
-
-# PHP Config
 
 CMD ["apache2-foreground"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,11 +5,11 @@ ENV DEBIAN_FRONTEND noninteractive
 
 RUN mkdir -p /var/run/apache2 /var/lock/apache2
 
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install software-properties-common
 
 RUN apt-get update && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 
 RUN apt-get update && apt-get install -y --force-yes\
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install apt-utils apt-transport-https software-properties-common
     # Apache\PHP
     apache2 libapache2-mod-gnutls libapache2-mod-php7.2 php7.2 php7.2-curl php7.2-common php7.2-dev php7.2-mbstring php7.2-curl php7.2-cli php7.2-mysql php7.2-gd php7.2-intl php7.2-xsl php7.2-zip php-xcache php-pear php7.2-gd php-xml-parser php-memcached libhiredis-dev libhiredis0.13 libphp-predis \
     # Mogile

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ RUN curl -s -o phpunit-7.3.2.phar https://phar.phpunit.de/phpunit-7.3.2.phar \
     && chmod 777 phpunit-7.3.2.phar \
     && mv phpunit-7.3.2.phar /usr/local/bin/phpunit \
     && pear install PHP_CodeSniffer \
-    && pecl install apcu-5.1.12 \
+    && pecl install apcu-5.1.12
 
 RUN a2enmod ssl \
     && a2enmod rewrite \

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,13 +39,13 @@ RUN apt-get update && apt-get install -y --force-yes \
 
 
 RUN docker-php-ext-configure gd \
-    --with-gd \
-    --with-webp-dir \
-    --with-jpeg-dir \
-    --with-png-dir \
-    --with-zlib-dir \
-    --with-xpm-dir \
-    --with-freetype-dir \
+    --with-gd=shared\
+    --with-webp-dir=/usr \
+    --with-jpeg-dir=/usr \
+    --with-png-dir=/usr \
+    --with-zlib-dir=/usr \
+    --with-xpm-dir=/usr \
+    --with-freetype-dir=/usr \
     --enable-gd-native-ttf \
     && pecl config-set php_ini "$PHP_INI_DIR" \
     && pear install PHP_CodeSniffer \

--- a/Dockerfile
+++ b/Dockerfile
@@ -77,8 +77,6 @@ ENV APACHE_RUN_DIR /var/run/apache2
 ENV APPLICATION_ENV local
 
 COPY apache2/apache2.conf /etc/apache2/
-COPY php/conf.d/* /usr/local/etc/php/7.2/apache2/conf.d/
-COPY php/conf.d/* /usr/local/etc/php/7.2/cli/conf.d/
 
 COPY apache2-foreground /usr/local/bin/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,9 +14,6 @@ RUN apt-get update && LC_ALL=C.UTF-8 add-apt-repository 'deb https://packages.su
 # except Prioritize Sury php-gd package
 RUN set -eux; \
 	{ \
-		echo 'Package: php*-redis'; \
-		echo 'Pin: release *'; \
-		echo 'Pin-Priority: 1'; \
 		echo 'Package: php*-gd'; \
 		echo 'Pin: release *'; \
 		echo 'Pin-Priority: 1'; \
@@ -24,7 +21,7 @@ RUN set -eux; \
 
 RUN apt-get update && apt-get install -y --force-yes \
     # Apache\PHP
-    php-redis libhiredis-dev libhiredis0.13  libphp-predis \
+    libhiredis-dev libhiredis0.13 libphp-predis \
     # Build Deps
     build-essential curl make \
     # Other Deps
@@ -32,7 +29,6 @@ RUN apt-get update && apt-get install -y --force-yes \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
     && docker-php-ext-install mysqli \
-    && docker-php-ext-install redis \
     && docker-php-ext-install gd
 
 
@@ -42,7 +38,8 @@ RUN curl -s -o phpunit-7.3.2.phar https://phar.phpunit.de/phpunit-7.3.2.phar \
 
 RUN pecl config-set php_ini "$PHP_INI_DIR" \
     && pear install PHP_CodeSniffer \
-    && pecl install apcu-5.1.12
+    && pecl install apcu-5.1.12 \
+    && pecl install redis-5.0.1
 
 RUN a2enmod ssl \
     && a2enmod rewrite \

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN set -eux; \
 
 RUN apt-get update && apt-get install -y --force-yes \
     # Apache\PHP
-    php7.2-dev php7.2-gd libhiredis-dev libhiredis0.13  libphp-predis \
+    php7.2-mysql php7.2-dev php7.2-gd libhiredis-dev libhiredis0.13  libphp-predis \
     # Build Deps
     build-essential curl make \
     # Other Deps

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ RUN apt-get update && apt-get install -y --force-yes \
     # Build Deps
     build-essential curl make \
     # Other Deps
-    pdftk zip git libpng-dev libjpeg-dev libfreetype6-dev
+    pdftk zip git libpng-dev libjpeg-dev libfreetype6-dev libwebp-dev
 
 
 RUN docker-php-ext-configure gd \

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,7 @@ RUN pecl config-set php_ini "$PHP_INI_DIR" \
     && pecl install apcu-5.1.12 \
     && pecl install redis-5.0.1 \
     && docker-php-ext-enable redis
+    && docker-php-ext-install mysqli \
 
 RUN a2enmod ssl \
     && a2enmod rewrite \

--- a/Dockerfile
+++ b/Dockerfile
@@ -80,5 +80,7 @@ COPY php/conf.d/* /usr/local/etc/php/7.2/cli/conf.d/
 
 COPY apache2-foreground /usr/local/bin/
 
+# PHP Config
+RUN mv "$PHP_INI_DIR/php.ini-production" "/usr/local/etc/php/php.ini"
 
 CMD ["apache2-foreground"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ENV DEBIAN_FRONTEND noninteractive
 
 RUN mkdir -p /var/run/apache2 /var/lock/apache2
 
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install apt-utils && apt-get -y install apt-transport-https software-properties-common
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install apt-utils apt-transport-https software-properties-common gnupg
 
 RUN apt-get update && LC_ALL=C.UTF-8 add-apt-repository 'deb https://packages.sury.org/php/ stretch main' \
     && apt-key adv --fetch-keys https://packages.sury.org/php/apt.gpg
@@ -25,7 +25,7 @@ RUN set -eux; \
 RUN apt-get update && apt-get install -y --force-yes \
     # Apache\PHP
     # Build Deps
-    build-essential curl make gnupg \
+    build-essential curl make \
     # Other Deps
     pdftk zip git \
     && apt-get clean \

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,7 @@ RUN pecl config-set php_ini "$PHP_INI_DIR" \
     && docker-php-ext-install mysqli \
     && docker-php-ext-install gd
 
-RUN php -m && ls -altr /usr/local/etc/php/conf.d && ls -altr /usr/local/etc/php/7.2/apache2/conf.d/
+RUN php -m && ls -altr /usr/local/etc/php/conf.d
 
 RUN curl -s -o phpunit-7.3.2.phar https://phar.phpunit.de/phpunit-7.3.2.phar \
     && chmod 777 phpunit-7.3.2.phar \
@@ -82,6 +82,6 @@ COPY php/conf.d/* /usr/local/etc/php/7.2/cli/conf.d/
 
 COPY apache2-foreground /usr/local/bin/
 
-RUN php -m && ls -altr /usr/local/etc/php/conf.d && ls -altr /usr/local/etc/php/7.2/apache2/conf.d/
+RUN php -m && ls -altr /usr/local/etc/php/conf.d
 
 CMD ["apache2-foreground"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,6 @@ RUN mkdir -p /var/run/apache2 /var/lock/apache2
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install apt-utils apt-transport-https software-properties-common gnupg
 
-RUN apt-get update && LC_ALL=C.UTF-8 add-apt-repository 'deb https://packages.sury.org/php/ stretch main' \
-    && apt-key adv --fetch-keys https://packages.sury.org/php/apt.gpg
 
 # Use the default production configuration
 # except Prioritize Sury php-gd package

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,16 @@ FROM php:7.2-apache-stretch
 MAINTAINER Firespring "info.dev@firespring.com"
 
 ENV DEBIAN_FRONTEND noninteractive
+ENV SERVER_NAME=localhost
+ENV APACHE_RUN_USER=www-data
+ENV APACHE_RUN_GROUP=www-data
+ENV APACHE_PID_FILE=/var/run/apache2/apache2.pid
+ENV APACHE_RUN_DIR=/var/run/apache2
+ENV APACHE_LOCK_DIR=/var/lock/apache2
+ENV APACHE_LOG_DIR=/var/log/apache2
+ENV APACHE_LOG_LEVEL=warn
+ENV APACHE_CUSTOM_LOG_FILE=/proc/self/fd/1
+ENV APACHE_ERROR_LOG_FILE=/proc/self/fd/2
 
 RUN mkdir -p /var/run/apache2 /var/lock/apache2
 
@@ -69,15 +79,5 @@ COPY php/conf.d/* /usr/local/etc/php/7.2/cli/conf.d/
 
 COPY apache2-foreground /usr/local/bin/
 
-ENV SERVER_NAME=localhost
-ENV APACHE_RUN_USER=www-data
-ENV APACHE_RUN_GROUP=www-data
-ENV APACHE_PID_FILE=/var/run/apache2/apache2.pid
-ENV APACHE_RUN_DIR=/var/run/apache2
-ENV APACHE_LOCK_DIR=/var/lock/apache2
-ENV APACHE_LOG_DIR=/var/log/apache2
-ENV APACHE_LOG_LEVEL=warn
-ENV APACHE_CUSTOM_LOG_FILE=/proc/self/fd/1
-ENV APACHE_ERROR_LOG_FILE=/proc/self/fd/2
 
 CMD ["apache2-foreground"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN set -eux; \
 
 RUN apt-get update && apt-get install -y --force-yes \
     # Apache\PHP
-    php*-mysql php*-dev php-gd libhiredis-dev libhiredis0.13 libphp-predis \
+    php*-mysql php*-dev php-gd php-redis libhiredis-dev libhiredis0.13 libphp-predis \
     # Build Deps
     build-essential curl make \
     # Other Deps

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,25 +35,16 @@ RUN apt-get update && apt-get install -y --force-yes \
     # Build Deps
     build-essential curl make \
     # Other Deps
-    pdftk zip git libpng-dev libjpeg-dev libfreetype6-dev libwebp-dev libxpm-dev
+    pdftk zip git libpng-dev libjpeg-dev libjpeg62-turbo-dev libfreetype6-dev libwebp-dev libxpm-dev
 
-
-RUN docker-php-ext-configure gd \
-    --with-gd=shared\
-    --with-webp-dir=/usr \
-    --with-jpeg-dir=/usr \
-    --with-png-dir=/usr \
-    --with-zlib-dir=/usr \
-    --with-xpm-dir=/usr \
-    --with-freetype-dir=/usr \
-    --enable-gd-native-ttf \
-    && pecl config-set php_ini "$PHP_INI_DIR" \
+RUN pecl config-set php_ini "$PHP_INI_DIR" \
     && pear install PHP_CodeSniffer \
     && pecl install apcu-5.1.12 \
     && pecl install redis-5.0.1 \
     && docker-php-ext-enable redis \
     && docker-php-ext-install mysqli \
-    && docker-php-ext-install gd
+    && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
+    && docker-php-ext-install -j$(nproc) gd
 
 RUN curl -s -o phpunit-7.3.2.phar https://phar.phpunit.de/phpunit-7.3.2.phar \
     && chmod 777 phpunit-7.3.2.phar \

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,18 +21,12 @@ RUN set -eux; \
 
 RUN apt-get update && apt-get install -y --force-yes \
     # Apache\PHP
-    php7.2-mysql php-gd libhiredis-dev libhiredis0.13 libphp-predis \
+    php*-mysql php*-dev php-gd libhiredis-dev libhiredis0.13 libphp-predis \
     # Build Deps
     build-essential curl make \
     # Other Deps
-    pdftk zip git libpng-dev libjpeg-dev \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+    pdftk zip git libpng-dev libjpeg-dev
 
-
-RUN curl -s -o phpunit-7.3.2.phar https://phar.phpunit.de/phpunit-7.3.2.phar \
-    && chmod 777 phpunit-7.3.2.phar \
-    && mv phpunit-7.3.2.phar /usr/local/bin/phpunit
 
 RUN pecl config-set php_ini "$PHP_INI_DIR" \
     && pear install PHP_CodeSniffer \
@@ -40,6 +34,10 @@ RUN pecl config-set php_ini "$PHP_INI_DIR" \
     && pecl install redis-5.0.1 \
     && docker-php-ext-install mysqli \
     && docker-php-ext-install gd
+
+RUN curl -s -o phpunit-7.3.2.phar https://phar.phpunit.de/phpunit-7.3.2.phar \
+    && chmod 777 phpunit-7.3.2.phar \
+    && mv phpunit-7.3.2.phar /usr/local/bin/phpunit
 
 RUN a2enmod ssl \
     && a2enmod rewrite \
@@ -56,6 +54,9 @@ RUN git clone https://github.com/nrk/phpiredis.git \
     && cd .. && rm -rf phpiredis
 
 RUN curl -sS https://getcomposer.org/installer | php && mv composer.phar /usr/local/bin/composer
+
+RUN apt-get clean \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Apache Config
 ENV APACHE_LOCK_DIR /var/lock/apache2

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ RUN curl -s -o phpunit-7.3.2.phar https://phar.phpunit.de/phpunit-7.3.2.phar \
 
 RUN pecl config-set php_ini "$PHP_INI_DIR" \
     && pear install PHP_CodeSniffer \
-    && pecl install apcu-5.1.12
+    && pecl install apcu-5.1.12 \
     && pecl install redis-5.0.1 \
     && docker-php-ext-enable redis
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,8 @@ RUN pecl config-set php_ini "$PHP_INI_DIR" \
     && pecl install apcu-5.1.12 \
     && pecl install redis-5.0.1 \
     && docker-php-ext-install mysqli \
-    && docker-php-ext-install gd
+    && docker-php-ext-install gd \
+    && docker-php-ext-enable redis
 
 RUN curl -s -o phpunit-7.3.2.phar https://phar.phpunit.de/phpunit-7.3.2.phar \
     && chmod 777 phpunit-7.3.2.phar \

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install apt-util
 
 RUN apt-get update && apt-get install -y --force-yes \
     # Apache\PHP
-    libhiredis-dev libhiredis0.13  libphp-predis \
+    php-redis libhiredis-dev libhiredis0.13  libphp-predis \
     # Build Deps
     build-essential curl make \
     # Other Deps

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,6 +49,12 @@ RUN a2enmod ssl \
 RUN a2dissite 000-default
 RUN a2dismod -f autoindex
 
+RUN git clone https://github.com/nrk/phpiredis.git \
+    && ls -altr \
+    && cd phpiredis \
+    && phpize && ./configure --enable-phpiredis \
+    && make && make install \
+    && cd .. && rm -rf phpiredis
 
 RUN curl -sS https://getcomposer.org/installer | php && mv composer.phar /usr/local/bin/composer
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,9 +18,9 @@ RUN set -eux; \
 		echo 'Pin: release *'; \
 		echo 'Pin-Priority: 1'; \
 	} >> /etc/apt/preferences.d/no-debian-php \
-    && mkdir -p /etc/php/7.2/apache2 && mkdir -p /etc/php/7.2/cli \
-    && cp "$PHP_INI_DIR/php.ini-production" "/etc/php/7.2/apache2/php.ini" \
-    && mv "$PHP_INI_DIR/php.ini-production" "/etc/php/7.2/cli/php.ini"
+    && mkdir -p /usr/local/etc/php/7.2/apache2 && mkdir -p /usr/local/etc/php/7.2/cli \
+    && cp "$PHP_INI_DIR/php.ini-production" "/usr/local/etc/php/7.2/apache2/php.ini" \
+    && mv "$PHP_INI_DIR/php.ini-production" "/usr/local/etc/php/7.2/cli/php.ini"
 
 RUN apt-get update && apt-get install -y --force-yes \
     # Apache\PHP

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,9 +42,11 @@ RUN pecl config-set php_ini "$PHP_INI_DIR" \
     && pear install PHP_CodeSniffer \
     && pecl install apcu-5.1.12 \
     && pecl install redis-5.0.1 \
+    && docker-php-ext-enable redis \
     && docker-php-ext-install mysqli \
-    && docker-php-ext-install gd \
-    && docker-php-ext-enable redis
+    && docker-php-ext-install gd
+
+RUN php -m && ls -altr /usr/local/etc/php/conf.d && ls -altr /usr/local/etc/php/7.2/apache2/conf.d/
 
 RUN curl -s -o phpunit-7.3.2.phar https://phar.phpunit.de/phpunit-7.3.2.phar \
     && chmod 777 phpunit-7.3.2.phar \
@@ -80,5 +82,6 @@ COPY php/conf.d/* /usr/local/etc/php/7.2/cli/conf.d/
 
 COPY apache2-foreground /usr/local/bin/
 
+RUN php -m && ls -altr /usr/local/etc/php/conf.d && ls -altr /usr/local/etc/php/7.2/apache2/conf.d/
 
 CMD ["apache2-foreground"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,11 +21,11 @@ RUN set -eux; \
 
 RUN apt-get update && apt-get install -y --force-yes \
     # Apache\PHP
-    libhiredis-dev libhiredis0.13 libphp-predis \
+    php-gd libhiredis-dev libhiredis0.13 libphp-predis \
     # Build Deps
     build-essential curl make \
     # Other Deps
-    pdftk zip git \
+    pdftk zip git libpng-dev libjpeg-dev \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
     && docker-php-ext-install mysqli \

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,8 +40,8 @@ RUN pecl config-set php_ini "$PHP_INI_DIR" \
     && pear install PHP_CodeSniffer \
     && pecl install apcu-5.1.12 \
     && pecl install redis-5.0.1 \
-    && docker-php-ext-enable redis
-    && docker-php-ext-install mysqli \
+    && docker-php-ext-enable redis \
+    && docker-php-ext-install mysqli
 
 RUN a2enmod ssl \
     && a2enmod rewrite \

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,16 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install apt-util
 RUN apt-get update && LC_ALL=C.UTF-8 add-apt-repository 'deb https://packages.sury.org/php/ stretch main' \
     && apt-key adv --fetch-keys https://packages.sury.org/php/apt.gpg
 
+# Use the default production configuration
+# except Prioritize Sury php-gd package
+RUN set -eux; \
+	{ \
+		echo 'Package: php*-gd'; \
+		echo 'Pin: release *'; \
+		echo 'Pin-Priority: 1'; \
+    && mkdir -p /etc/php/7.2/apache2 && mkdir -p /etc/php/7.2/cli \
+    && cp "$PHP_INI_DIR/php.ini-development" "/etc/php/7.2/apache2/php.ini"
+	} >> /etc/apt/preferences.d/no-debian-php
 RUN apt-get update && apt-get install -y --force-yes \
     # Apache\PHP
     apache2 libapache2-mod-gnutls libapache2-mod-php7.2 php7.2 php7.2-curl php7.2-common php7.2-dev php7.2-mbstring php7.2-curl php7.2-cli php7.2-mysql php7.2-gd php7.2-intl php7.2-xsl php7.2-zip php-xcache php-pear php7.2-gd php-xml-parser php-memcached libhiredis-dev libhiredis0.13 libphp-predis \

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,8 @@ RUN mkdir -p /var/run/apache2 /var/lock/apache2
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install apt-utils apt-transport-https software-properties-common gnupg
 
+RUN apt-get update && LC_ALL=C.UTF-8 add-apt-repository 'deb https://packages.sury.org/php/ stretch main' \
+    && apt-key adv --fetch-keys https://packages.sury.org/php/apt.gpg
 
 # Use the default production configuration
 # except Prioritize Sury php-gd package

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM php:7.2-apache-stretch
 MAINTAINER Firespring "info.dev@firespring.com"
 
 ENV DEBIAN_FRONTEND noninteractive

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ RUN set -eux; \
 
 RUN apt-get update && apt-get install -y --force-yes \
     # Apache\PHP
+    libphp-predis \
     # Build Deps
     build-essential curl make \
     # Other Deps
@@ -33,9 +34,13 @@ RUN apt-get update && apt-get install -y --force-yes \
 
 RUN curl -s -o phpunit-7.3.2.phar https://phar.phpunit.de/phpunit-7.3.2.phar \
     && chmod 777 phpunit-7.3.2.phar \
-    && mv phpunit-7.3.2.phar /usr/local/bin/phpunit \
+    && mv phpunit-7.3.2.phar /usr/local/bin/phpunit
+
+RUN pecl config-set php_ini "$PHP_INI_DIR" \
     && pear install PHP_CodeSniffer \
     && pecl install apcu-5.1.12
+    && pecl install redis-5.0.1 \
+    && docker-php-ext-enable redis
 
 RUN a2enmod ssl \
     && a2enmod rewrite \

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,11 +37,14 @@ RUN curl -s -o phpunit-7.3.2.phar https://phar.phpunit.de/phpunit-7.3.2.phar \
     && mv phpunit-7.3.2.phar /usr/local/bin/phpunit
 
 RUN pecl config-set php_ini "$PHP_INI_DIR" \
+    && pecl install xdebug-2.6.1 \
     && pear install PHP_CodeSniffer \
     && pecl install apcu-5.1.12 \
     && pecl install redis-5.0.1 \
     && docker-php-ext-enable redis \
     && docker-php-ext-install mysqli
+    && docker-php-ext-install mysqli \
+    && docker-php-ext-enable redis xdebug
 
 RUN a2enmod ssl \
     && a2enmod rewrite \

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ENV DEBIAN_FRONTEND noninteractive
 
 RUN mkdir -p /var/run/apache2 /var/lock/apache2
 
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install apt-utils apt-transport-https software-properties-common
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install apt-utils && apt-get -y install apt-transport-https software-properties-common
 
 RUN apt-get update && LC_ALL=C.UTF-8 add-apt-repository 'deb https://packages.sury.org/php/ stretch main' \
     && apt-key adv --fetch-keys https://packages.sury.org/php/apt.gpg

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ RUN pecl config-set php_ini "$PHP_INI_DIR" \
     && pecl install apcu-5.1.12 \
     && pecl install redis-5.0.1 \
     && docker-php-ext-enable redis \
-    && docker-php-ext-enable redis xdebug
+    && docker-php-ext-enable redis xdebug mysqli
 
 RUN a2enmod ssl \
     && a2enmod rewrite \

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,8 +42,7 @@ RUN pecl config-set php_ini "$PHP_INI_DIR" \
     && pecl install apcu-5.1.12 \
     && pecl install redis-5.0.1 \
     && docker-php-ext-enable redis \
-    && docker-php-ext-install mysqli \
-    && docker-php-ext-enable redis xdebug mysqli
+    && docker-php-ext-enable redis xdebug
 
 RUN a2enmod ssl \
     && a2enmod rewrite \

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,8 +33,7 @@ RUN apt-get update && apt-get install -y --force-yes \
 
 RUN curl -s -o phpunit-7.3.2.phar https://phar.phpunit.de/phpunit-7.3.2.phar \
     && chmod 777 phpunit-7.3.2.phar \
-    && mv phpunit-7.3.2.phar /usr/local/bin/phpunit
-
+    && mv phpunit-7.3.2.phar /usr/local/bin/phpunit \
     && pear install PHP_CodeSniffer \
     && pecl install apcu-5.1.12 \
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,8 @@ RUN set -eux; \
 
 RUN apt-get update && apt-get install -y --force-yes \
     # Apache\PHP
-    php*-mysql php*-dev php*-gd php-redis libhiredis-dev libhiredis0.13 libphp-predis \
+    php-mysql php-dev php-gd php-redis libhiredis-dev libhiredis0.13 libphp-predis \
+    libapache2-mod-gnutls php-zip php-cli php-xcache \
     # Build Deps
     build-essential curl make \
     # Other Deps

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,9 +24,6 @@ RUN set -eux; \
 
 RUN apt-get update && apt-get install -y --force-yes \
     # Apache\PHP
-    apache2 libapache2-mod-gnutls libapache2-mod-php7.2 php7.2 php7.2-curl php7.2-common php7.2-dev php7.2-mbstring php7.2-curl php7.2-cli php7.2-mysql php7.2-gd php7.2-intl php7.2-xsl php7.2-zip php-xcache php-pear php7.2-gd php-xml-parser php-memcached libhiredis-dev libhiredis0.13 libphp-predis \
-    # Mogile
-    libpcre3-dev libxml2-dev libneon27-dev libzip-dev zlib1g-dev libmemcached-dev \
     # Build Deps
     build-essential curl make \
     # Other Deps
@@ -38,27 +35,16 @@ RUN curl -s -o phpunit-7.3.2.phar https://phar.phpunit.de/phpunit-7.3.2.phar \
     && chmod 777 phpunit-7.3.2.phar \
     && mv phpunit-7.3.2.phar /usr/local/bin/phpunit
 
-RUN pecl install xdebug-2.6.1 \
     && pear install PHP_CodeSniffer \
     && pecl install apcu-5.1.12 \
-    && echo no | pecl install memcached \
-    && pecl install redis \
-    && pecl install zip
 
 RUN a2enmod ssl \
-    && a2enmod php7.2 \
     && a2enmod rewrite \
     && a2enmod headers
 
 RUN a2dissite 000-default
 RUN a2dismod -f autoindex
 
-RUN git clone https://github.com/nrk/phpiredis.git \
-    && ls -altr \
-    && cd phpiredis \
-    && phpize && ./configure --enable-phpiredis \
-    && make && make install \
-    && cd .. && rm -rf phpiredis
 
 RUN curl -sS https://getcomposer.org/installer | php && mv composer.phar /usr/local/bin/composer
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,10 @@ RUN apt-get update && apt-get install -y --force-yes \
     # Other Deps
     pdftk zip git \
     && apt-get clean \
-    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
+    && docker-php-ext-install mysqli \
+    && docker-php-ext-install redis \
+    && docker-php-ext-install gd
 
 
 RUN curl -s -o phpunit-7.3.2.phar https://phar.phpunit.de/phpunit-7.3.2.phar \
@@ -28,9 +31,7 @@ RUN curl -s -o phpunit-7.3.2.phar https://phar.phpunit.de/phpunit-7.3.2.phar \
 
 RUN pecl config-set php_ini "$PHP_INI_DIR" \
     && pear install PHP_CodeSniffer \
-    && pecl install apcu-5.1.12 \
-    && pecl install redis-5.0.1 \
-    && docker-php-ext-enable redis
+    && pecl install apcu-5.1.12
 
 RUN a2enmod ssl \
     && a2enmod rewrite \

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,6 @@ RUN pecl config-set php_ini "$PHP_INI_DIR" \
     && pear install PHP_CodeSniffer \
     && pecl install apcu-5.1.12 \
     && pecl install redis-5.0.1 \
-    && docker-php-ext-enable redis \
     && docker-php-ext-enable redis xdebug mysqli
 
 RUN a2enmod ssl \

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN set -eux; \
 RUN apt-get update && apt-get install -y --force-yes \
     # Apache\PHP
     # Build Deps
-    build-essential curl make \
+    build-essential curl make gnupg \
     # Other Deps
     pdftk zip git \
     && apt-get clean \

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,11 +24,6 @@ RUN apt-get update && apt-get install -y --force-yes \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 
-ADD https://raw.githubusercontent.com/mlocati/docker-php-extension-installer/master/install-php-extensions /usr/local/bin/
-
-RUN chmod uga+x /usr/local/bin/install-php-extensions && sync && \
-    install-php-extensions gd xdebug mysqli
-
 RUN curl -s -o phpunit-7.3.2.phar https://phar.phpunit.de/phpunit-7.3.2.phar \
     && chmod 777 phpunit-7.3.2.phar \
     && mv phpunit-7.3.2.phar /usr/local/bin/phpunit
@@ -38,7 +33,6 @@ RUN pecl config-set php_ini "$PHP_INI_DIR" \
     && pecl install apcu-5.1.12 \
     && pecl install redis-5.0.1 \
     && docker-php-ext-enable redis
-
 
 RUN a2enmod ssl \
     && a2enmod rewrite \

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,7 @@ RUN apt-get update && apt-get install -y --force-yes \
 
 RUN pecl config-set php_ini "$PHP_INI_DIR" \
     && pear install PHP_CodeSniffer \
+    && pecl install xdebug-2.6.1 \
     && pecl install apcu-5.1.12 \
     && pecl install redis-5.0.1 \
     && docker-php-ext-enable redis \

--- a/php/conf.d/30-redis.ini
+++ b/php/conf.d/30-redis.ini
@@ -1,1 +1,0 @@
-extension="redis.so"

--- a/php/conf.d/40-apcu.ini
+++ b/php/conf.d/40-apcu.ini
@@ -1,1 +1,0 @@
-extension="apcu.so"

--- a/php/conf.d/50-mysqli.ini
+++ b/php/conf.d/50-mysqli.ini
@@ -1,0 +1,1 @@
+extension="php_mysqli.so"

--- a/php/conf.d/50-mysqli.ini
+++ b/php/conf.d/50-mysqli.ini
@@ -1,1 +1,0 @@
-extension="php_mysqli.so"


### PR DESCRIPTION
- official php is debian rather than ubuntu so the ppa's don't work.  
- Added Sury the debian way and added a priority bypass so we could get the php-gd packages. 
- Stripped out all the apache and php installation commands since they are already installed
- Added back only the missing libraries and installed/enabled extensions using the docker-php-ext-* commands. This is the recommended method as the old way installs side versions of php. 
- Removed the redis and apcu .ini files as the docker-php-est-* commands install the extension configs in the correct location. 