### PR TITLE
7.2 official - Story/TP-48573 Update PHP to use the official container from dockerhub

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ RUN apt-get update && apt-get install -y --force-yes \
     pdftk zip git libpng-dev libjpeg-dev libjpeg62-turbo-dev libfreetype6-dev libwebp-dev libxpm-dev
 
 RUN pecl config-set php_ini "$PHP_INI_DIR" \
-    && pear install PHP_CodeSniffer \
+    && pear install PHP_CodeSniffer-3.3.2 \
     && pecl install xdebug-2.6.1 \
     && pecl install apcu-5.1.12 \
     && docker-php-ext-enable apcu \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,39 +1,60 @@
-FROM ubuntu:16.04
+FROM php:7.2-apache-stretch
 MAINTAINER Firespring "info.dev@firespring.com"
 
 ENV DEBIAN_FRONTEND noninteractive
+ENV SERVER_NAME=localhost
+ENV APACHE_RUN_USER=www-data
+ENV APACHE_RUN_GROUP=www-data
+ENV APACHE_PID_FILE=/var/run/apache2/apache2.pid
+ENV APACHE_RUN_DIR=/var/run/apache2
+ENV APACHE_LOCK_DIR=/var/lock/apache2
+ENV APACHE_LOG_DIR=/var/log/apache2
+ENV APACHE_LOG_LEVEL=warn
+ENV APACHE_CUSTOM_LOG_FILE=/proc/self/fd/1
+ENV APACHE_ERROR_LOG_FILE=/proc/self/fd/2
 
 RUN mkdir -p /var/run/apache2 /var/lock/apache2
 
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install software-properties-common
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install apt-utils apt-transport-https software-properties-common gnupg
 
-RUN apt-get update && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
+RUN apt-get update && LC_ALL=C.UTF-8 add-apt-repository 'deb https://packages.sury.org/php/ stretch main' \
+    && apt-key adv --fetch-keys https://packages.sury.org/php/apt.gpg
 
-RUN apt-get update && apt-get install -y --force-yes\
+# Use the default production configuration
+# except Prioritize Sury php-gd package
+RUN set -eux; \
+	{ \
+		echo 'Package: php*-gd'; \
+		echo 'Pin: release *'; \
+		echo 'Pin-Priority: 1'; \
+	} >> /etc/apt/preferences.d/no-debian-php
+
+RUN apt-get update && apt-get install -y --force-yes \
     # Apache\PHP
-    apache2 libapache2-mod-gnutls libapache2-mod-php7.2 php7.2 php7.2-curl php7.2-common php7.2-dev php7.2-mbstring php7.2-curl php7.2-cli php7.2-mysql php7.2-gd php7.2-intl php7.2-xsl php7.2-zip php-xcache php-pear php7.2-gd php-xml-parser php-memcached libhiredis-dev libhiredis0.13 libphp-predis \
-    # Mogile
-    libpcre3-dev libxml2-dev libneon27-dev libzip-dev zlib1g-dev libmemcached-dev \
+    php-mysql php-dev php-gd php-redis libhiredis-dev libhiredis0.13 libphp-predis \
+    libapache2-mod-gnutls php-zip php-cli php-xcache \
     # Build Deps
     build-essential curl make \
     # Other Deps
-    pdftk zip git \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+    pdftk zip git libpng-dev libjpeg-dev libjpeg62-turbo-dev libfreetype6-dev libwebp-dev libxpm-dev
+
+RUN pecl config-set php_ini "$PHP_INI_DIR" \
+    && pear install PHP_CodeSniffer \
+    && pecl install xdebug-2.6.1 \
+    && pecl install apcu-5.1.12 \
+    && docker-php-ext-enable apcu \
+    && pecl install redis-5.0.1 \
+    && docker-php-ext-enable redis \
+    && docker-php-ext-install mysqli \
+    && docker-php-ext-install zip \
+    && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
+    && docker-php-ext-install -j$(nproc) gd
 
 RUN curl -s -o phpunit-7.3.2.phar https://phar.phpunit.de/phpunit-7.3.2.phar \
     && chmod 777 phpunit-7.3.2.phar \
     && mv phpunit-7.3.2.phar /usr/local/bin/phpunit
 
-RUN pecl install xdebug-2.6.1 \
-    && pear install PHP_CodeSniffer \
-    && pecl install apcu-5.1.12 \
-    && echo no | pecl install memcached \
-    && pecl install redis \
-    && pecl install zip
-
 RUN a2enmod ssl \
-    && a2enmod php7.2 \
     && a2enmod rewrite \
     && a2enmod headers
 
@@ -49,26 +70,16 @@ RUN git clone https://github.com/nrk/phpiredis.git \
 
 RUN curl -sS https://getcomposer.org/installer | php && mv composer.phar /usr/local/bin/composer
 
+RUN apt-get clean \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
 # Apache Config
 ENV APACHE_LOCK_DIR /var/lock/apache2
 ENV APACHE_RUN_DIR /var/run/apache2
 ENV APPLICATION_ENV local
 
 COPY apache2/apache2.conf /etc/apache2/
-COPY php/conf.d/ /etc/php/7.2/apache2/conf.d/
-COPY php/conf.d/ /etc/php/7.2/cli/conf.d/
 
 COPY apache2-foreground /usr/local/bin/
-
-ENV SERVER_NAME=localhost
-ENV APACHE_RUN_USER=www-data
-ENV APACHE_RUN_GROUP=www-data
-ENV APACHE_PID_FILE=/var/run/apache2/apache2.pid
-ENV APACHE_RUN_DIR=/var/run/apache2
-ENV APACHE_LOCK_DIR=/var/lock/apache2
-ENV APACHE_LOG_DIR=/var/log/apache2
-ENV APACHE_LOG_LEVEL=warn
-ENV APACHE_CUSTOM_LOG_FILE=/proc/self/fd/1
-ENV APACHE_ERROR_LOG_FILE=/proc/self/fd/2
 
 CMD ["apache2-foreground"]

--- a/php/conf.d/30-redis.ini
+++ b/php/conf.d/30-redis.ini
@@ -1,1 +1,0 @@
-extension="redis.so"

--- a/php/conf.d/40-apcu.ini
+++ b/php/conf.d/40-apcu.ini
@@ -1,1 +1,0 @@
-extension="apcu.so"


### PR DESCRIPTION
- official php is debian rather than ubuntu so the ppa's don't work.  
- Added Sury the debian way and added a priority bypass so we could get the php-gd packages. 
- Stripped out all the apache and php installation commands since they are already installed
- Added back only the missing libraries and installed/enabled extensions using the docker-php-ext-* commands. This is the recommended method as the old way installs side versions of php. 
- Removed the redis and apcu .ini files as the docker-php-est-* commands install the extension configs in the correct location. 